### PR TITLE
fixing screen capture

### DIFF
--- a/src/View.js
+++ b/src/View.js
@@ -224,21 +224,24 @@ View.prototype = {
 		var oldWidth = canvas.width;
 		var oldHeight = canvas.height;
 
-		options = _.merge({
+		options = _.extend({
 			width: oldWidth,
 			height: oldHeight,
 			format: 'jpeg'
 		}, options);
 		var format = options.format === 'jpg' ? 'jpeg' : options.format;
 
+		console.log("OPTIONS", options)
+
 	    canvas.width = options.width;
         canvas.height = options.height;
-	    
+		// this.setSize(options.width, options.height);
+		
 	    var type = ['image/', format].join('');
 	    var imageData = canvas.toDataURL(type, options.encoderOptions);
 	    this.renderManager.render();
-        canvas.width = oldWidth;
-        canvas.height = oldHeight;
+        
+        // this.setSize(oldWidth, oldHeight);
 	    return imageData;
 	}
 };

--- a/src/View.js
+++ b/src/View.js
@@ -236,12 +236,12 @@ View.prototype = {
 		var type = 'image/' + format;
 		var oldSkip = this.skipRender;
 		this.skipRender = false;
-	    this.renderManager.render();
-	    this.skipRender = oldSkip;
-        
-	    var imageData = canvas.toDataURL(type, options.encoderOptions);
-        this.setSize(oldWidth, oldHeight);
-	    return imageData;
+		this.renderManager.render();
+		this.skipRender = oldSkip;
+
+		var imageData = canvas.toDataURL(type, options.encoderOptions);
+		this.setSize(oldWidth, oldHeight);
+		return imageData;
 	}
 };
 

--- a/src/View.js
+++ b/src/View.js
@@ -224,7 +224,7 @@ View.prototype = {
 		var oldWidth = this.domSize.x;
 		var oldHeight = this.domSize.y;
 
-		options = _.extend({
+		options = _.merge({
 			width: oldWidth,
 			height: oldHeight,
 			format: 'jpeg'
@@ -233,7 +233,7 @@ View.prototype = {
 
 		this.setSize(options.width, options.height);
 		
-		var type = ['image/', format].join('');
+		var type = 'image/' + format;
 		var oldSkip = this.skipRender;
 		this.skipRender = false;
 	    this.renderManager.render();

--- a/src/View.js
+++ b/src/View.js
@@ -221,8 +221,8 @@ View.prototype = {
 
 	captureImageData: function(options) {
 		var canvas = this.canvas;
-		var oldWidth = canvas.width;
-		var oldHeight = canvas.height;
+		var oldWidth = this.domSize.x;
+		var oldHeight = this.domSize.y;
 
 		options = _.extend({
 			width: oldWidth,
@@ -231,17 +231,16 @@ View.prototype = {
 		}, options);
 		var format = options.format === 'jpg' ? 'jpeg' : options.format;
 
-		console.log("OPTIONS", options)
-
-	    canvas.width = options.width;
-        canvas.height = options.height;
-		// this.setSize(options.width, options.height);
+		this.setSize(options.width, options.height);
 		
-	    var type = ['image/', format].join('');
-	    var imageData = canvas.toDataURL(type, options.encoderOptions);
+		var type = ['image/', format].join('');
+		var oldSkip = this.skipRender;
+		this.skipRender = false;
 	    this.renderManager.render();
+	    this.skipRender = oldSkip;
         
-        // this.setSize(oldWidth, oldHeight);
+	    var imageData = canvas.toDataURL(type, options.encoderOptions);
+        this.setSize(oldWidth, oldHeight);
 	    return imageData;
 	}
 };

--- a/src/View.js
+++ b/src/View.js
@@ -220,22 +220,26 @@ View.prototype = {
 	},
 
 	captureImageData: function(options) {
+		var canvas = this.canvas;
+		var oldWidth = canvas.width;
+		var oldHeight = canvas.height;
+
 		options = _.merge({
-			width: 800,
-			height: 600,
-			format: 'jpeg'	//or png
-		}, options || {});
-		if(options.format == 'jpg') options.format = 'jpeg';
-		var backupSize = this.getSize();
-		var backupResolution = this.getResolution();
-		this.setSize(options.width, options.height, true);
-		this.setResolution(options.width, options.height);
-		this.renderManager.render();
-		var imageData = this.canvas.toDataURL("image/" + options.format);
-		this.setSize(backupSize.width, backupSize.height);
-		this.setResolution(backupResolution.width, backupResolution.height);
-		this.renderManager.render();
-		return imageData;
+			width: oldWidth,
+			height: oldHeight,
+			format: 'jpeg'
+		}, options);
+		var format = options.format === 'jpg' ? 'jpeg' : options.format;
+
+	    canvas.width = options.width;
+        canvas.height = options.height;
+	    
+	    var type = ['image/', format].join('');
+	    var imageData = canvas.toDataURL(type, options.encoderOptions);
+	    this.renderManager.render();
+        canvas.width = oldWidth;
+        canvas.height = oldHeight;
+	    return imageData;
 	}
 };
 


### PR DESCRIPTION
- width and height defaults to the current canvas size (800x600 seemed arbitrary?)
- avoids skipRender issues
- fixing setSize so it resets the canvas size back to its initial state
- allow `options.encoderOptions` for better quality
